### PR TITLE
Make sure to start MongoDB server to make tests happy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ provide specs to your contribution.
 
     $ gem install bundler
     $ bundle install 
+    $ start MongoDB server (it is expected to listen on TCP port 27017)
     $ bundle exec guard
 
 Press enter to execute all specs.


### PR DESCRIPTION
Warn to user to start MongoDB server before running tests. Also, tests
was failing because I did not have the tmp/cache dir, so I'm adding it
here.